### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.0.4
 
       - name: Setup Java
-        uses: actions/setup-java@v2.5.0
+        uses: actions/setup-java@v3.0.0
         with:
           java-version: 11
           distribution: adopt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           GIT_EMAIL: ${{ secrets.CI_USER_GIT_EMAIL }}
 
       - name: Setup Java
-        uses: actions/setup-java@v2.5.0
+        uses: actions/setup-java@v3.0.0
         with:
           java-version: 11
           distribution: adopt


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release [v3.0.0](https://github.com/actions/setup-java/releases/tag/v3.0.0) on 2022-02-24T13:22:59Z
